### PR TITLE
CDATA-1004 making plugin compatible with logstash 7

### DIFF
--- a/lib/logstash/outputs/gcs/path_factory.rb
+++ b/lib/logstash/outputs/gcs/path_factory.rb
@@ -80,7 +80,7 @@ module LogStash
               prefix: @prefix,
               host: Socket.gethostname,
               date: Time.now.strftime(@date_pattern),
-              partf: '%03d' % @part_number,
+              partf: '%03d' % (@part_number.nil? ? 0 : @part_number),
               uuid: SecureRandom.uuid
           }
         end

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '4.0.1'
+  s.version         = '4.0.1.logstash.v7'
   s.licenses        = ['Apache-2.0']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixing plugin to be compatible with lostash7 (tested on logstash v7.3.2).
This fix was taken from commit here: https://github.com/logstash-plugins/logstash-output-google_cloud_storage/commit/8445e7280a01a1d7bacbbe3004d4568e4fdfcffd

Bumped version to more descriptive `4.0.1.logstash.v7`.